### PR TITLE
Add example for using RDK Lib

### DIFF
--- a/examples/cognitorule.py
+++ b/examples/cognitorule.py
@@ -1,0 +1,99 @@
+import json
+import boto3
+import os
+
+from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType, ClientFactory
+from rdklib.evaluation import build_annotation
+
+RESOURCE_TYPE = 'AWS::::Account'
+
+class CognitoUserPoolRule (ConfigRule):
+        
+    # for handling the periodic config notifications, implement evaluate_periodic method  
+    def evaluate_periodic(self, event, client_factory, valid_rule_parameters):
+
+        evaluations = []
+        client_factory = ClientFactory(self.get_execution_role_arn(event))
+        
+        pool_list={}
+        response=[]
+    
+        try:
+            cognitoclient = client_factory.build_client('cognito-idp')
+        except:
+            annotation = build_annotation('Unable to get Cognito client access')
+            evaluations.append(Evaluation(
+                        ComplianceType.NON_COMPLIANT, {},
+                        resourceType=RESOURCE_TYPE,
+                        annotation=annotation))
+            return evaluations
+    
+        next_batch = cognitoclient.list_user_pools(MaxResults=50)
+    
+        # check if there are more results
+        if 'NetToken' in next_batch:
+            response += next_batch
+            while 'NetToken' in next_batch:
+                next_batch = cognitoclient.list_user_pools(
+                                                        MaxResults=50,
+                                                        NextToken=next_batch['NextToken']
+                                                    )
+                response += next_batch
+    
+        response = next_batch['UserPools']
+    
+        poolids = [poolidlist['Id'] for poolidlist in response]
+        
+        for a in response:
+            pool_list[a['Id']] = a['Name']
+    
+        for poolid in poolids:
+            response = cognitoclient.list_identity_providers(UserPoolId=poolid)
+    
+            # for local user database, there won't be any identity providers
+            if not response['Providers']:
+                annotation = build_annotation('No SAML or OIDC providers for user pool {}:{}'.format(poolid, pool_list[poolid]))
+                evaluations.append(Evaluation(
+                            ComplianceType.NON_COMPLIANT, pool_list[poolid],
+                            resourceType=RESOURCE_TYPE,
+                            annotation=annotation))
+                return evaluations
+
+            else:
+                for providers in response['Providers']:
+                    id_response = cognitoclient.describe_identity_provider(
+                                                    UserPoolId=poolid,
+                                                    ProviderName=providers['ProviderName']
+                                                )['IdentityProvider']
+    
+                    if not ((id_response['ProviderType'] == 'SAML') or (id_response['ProviderType'] == 'OIDC')):
+                        annotation = build_annotation('User pool {} with identity provider {} of type {}'.format(id_response['UserPoolId'], id_response['ProviderName'], id_response['ProviderType']))
+                        evaluations.append(Evaluation(
+                                    ComplianceType.NON_COMPLIANT, pool_list[poolid],
+                                    resourceType=RESOURCE_TYPE,
+                                    annotation=annotation))
+                        return evaluations
+
+    
+        annotation = build_annotation('Compliant')
+        evaluations.append(Evaluation(
+                        ComplianceType.COMPLIANT, {},
+                        resourceType=RESOURCE_TYPE,
+                        annotation=annotation))
+        return evaluations
+
+def lambda_handler(event, context):
+
+    # create an instance of the Config rule which is set to periodically evaluate Cognito user pool
+    cognitouserpool_rule = CognitoUserPoolRule()
+    
+    # Execution role for Config rule evaluation can either be set as Config rule parameter or can be set through
+    # Lambda environment variable. Since this Config rule to evaluate Cognito user pool is evaluated in security 
+    # account, setting an execution role configured in security account
+     
+    role = os.environ['RULE_EXECUTION_ROLE']
+    cognitouserpool_rule.set_execution_arn(role)
+    
+    evaluator = Evaluator(cognitouserpool_rule)
+    return evaluator.handle(event, context)
+

--- a/rdklib/configrule.py
+++ b/rdklib/configrule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at
@@ -13,9 +13,14 @@ import json
 class ConfigRule:
     #Set this to True to prevent removal of old evaluations when evaluate_compliance returns a list of compliance results.
     delete_old_evaluations_on_scheduled_notification = True
+    #Execution role for evaluating the resources
+    __execution_role = None
 
     def __init__(self):
         pass
+
+    def set_execution_arn(self, role):
+        self.__execution_role = role
 
     def evaluate_parameters(self, rule_parameters):
         return rule_parameters
@@ -27,8 +32,11 @@ class ConfigRule:
         raise MissingTriggerHandlerError("You must implement the evaluate_periodic method of the ConfigRule class.")
 
     def get_execution_role_arn(self, event):
-        role_arn = None
-        if event['ruleParameters']:
+        # Initialize role ARN  
+        role_arn = self.__execution_role 
+
+        # make sure ruleParameter has values
+        if 'ruleParameters' in event:
             rule_params = json.loads(event['ruleParameters'])
             role_name = rule_params.get("ExecutionRoleName")
             if role_name:


### PR DESCRIPTION
*Issue #, if available:*
- in a multi-account environment, Config rule parameter may not carry the execution role
- missing example to use rdklib

*Description of changes:*
- change configrule.py to set execution role based on parameter passed 
- change configrule::get_execution_role_arn to handle scenario where ruleParameters are empty
- add example to use rdklib 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
