### PR TITLE
Enabling region specific ClientFactory

### DIFF
--- a/rdklib/clientfactory.py
+++ b/rdklib/clientfactory.py
@@ -19,8 +19,11 @@ class ClientFactory:
     __sts_credentials = None
     __role_arn = None
 
-    def __init__(self, role_arn):
+    def __init__(self, role_arn, region=None):
         self.__role_arn = role_arn
+        if region == None:
+            region = os.environ.get('AWS_REGION')
+        self.__region = region
 
     def build_client(self, service):
         if not self.__role_arn:
@@ -34,11 +37,12 @@ class ClientFactory:
         return boto3.client(service,
                             aws_access_key_id=self.__sts_credentials['AccessKeyId'],
                             aws_secret_access_key=self.__sts_credentials['SecretAccessKey'],
-                            aws_session_token=self.__sts_credentials['SessionToken'])
+                            aws_session_token=self.__sts_credentials['SessionToken'],
+                            region_name=self.__region)
 
-def get_assume_role_credentials(role_arn):
+def get_assume_role_credentials(role_arn, region):
     try:
-        region = os.environ.get('AWS_REGION')
+        #region = os.environ.get('AWS_REGION')
         try:
             #use region specific url for sts client is recommended. In some cases, company firewall policies are blocking the global endpoint sts.amazonaws.com
             assume_role_response = boto3.client('sts', region_name=region, endpoint_url="https://sts." + region + ".amazonaws.com").assume_role(RoleArn=role_arn,RoleSessionName="configLambdaExecution",DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)

--- a/rdklib/clientfactory.py
+++ b/rdklib/clientfactory.py
@@ -18,6 +18,7 @@ CONFIG_ROLE_TIMEOUT_SECONDS = 900
 class ClientFactory:
     __sts_credentials = None
     __role_arn = None
+    __region = None
 
     def __init__(self, role_arn, region=None):
         self.__role_arn = role_arn
@@ -31,7 +32,7 @@ class ClientFactory:
 
         # Check to see if we have already gotten STS credentials for this role.  If not, get them now and then save them for later use.
         if not self.__sts_credentials:
-            self.__sts_credentials = get_assume_role_credentials(self.__role_arn)
+            self.__sts_credentials = get_assume_role_credentials(self.__role_arn, self.__region)
 
         # Use the credentials to get a new boto3 client for the appropriate service.
         return boto3.client(service,


### PR DESCRIPTION
*Issue #, if available:*

If multi-region Config item change/scheduled notification is funneled into a central Lambda function, then it is necessary to access region specific appropriate service client for evaluating a resource.

*Description of changes:*

In the ClientFactory class, enable specifying region & also using the same while creating appropriate service client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
