### PR TITLE
Updating NextToken in get_compliance_details_by_config_rule call

### DIFF
--- a/rdklib/util/evaluations.py
+++ b/rdklib/util/evaluations.py
@@ -76,7 +76,7 @@ def clean_up_old_evaluations(event, client_factory, latest_evaluations):
             NextToken=next_token)
 
         old_evals.extend(compliance_details['EvaluationResults'])
-        next_token = compliance_details.get('nextToken', '')
+        next_token = compliance_details.get('NextToken', '')
         if not next_token:
             break
 


### PR DESCRIPTION
*Description of changes:*
The Boto3 call get_compliance_details_by_config_rule returns "NextToken" if there are more than 100 existing non-compliant resources. Before this purposed change, the call was only ever returning the first 100 non-compliant resources, meaning that if you had more than 100 non-compliant resources, not all of them would be processed. This change allows the NextToken logic to work correctly, so that you can retrieve and process all of your existing non-compliant resource for a given rule. 

[Boto3 Reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/config.html#ConfigService.Client.get_compliance_details_by_config_rule)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
