### PR TITLE
Added is_applicable flag which allows the user to determine if a reso…

### DIFF
--- a/rdklib/evaluator.py
+++ b/rdklib/evaluator.py
@@ -21,8 +21,9 @@ class Evaluator:
     __rdk_rule = None
     __expected_resource_types = None
 
-    def __init__(self, config_rule, expected_resource_types=None):
+    def __init__(self, config_rule, expected_resource_types=None, is_applicable_status=False):
         self.__rdk_rule = config_rule
+        self.is_applicable = is_applicable_status
         if expected_resource_types is None:
             self.__expected_resource_types = []
         else:
@@ -52,7 +53,7 @@ class Evaluator:
                 if not self.__expected_resource_types:
                     raise Exception("Change triggered rules must provide expected resource types")
                 configuration_item = get_configuration_item(invoking_event)
-                if is_applicable_status(configuration_item, event) and is_applicable_resource_type(configuration_item, self.__expected_resource_types):
+                if is_applicable_status(configuration_item, event, is_applicable=self.is_applicable) and is_applicable_resource_type(configuration_item, self.__expected_resource_types):
                     compliance_result = self.__rdk_rule.evaluate_change(event, client_factory, configuration_item, valid_rule_parameters)
                 else:
                     compliance_result = [Evaluation(ComplianceType.NOT_APPLICABLE)]

--- a/rdklib/util/service.py
+++ b/rdklib/util/service.py
@@ -8,9 +8,12 @@ def check_defined(reference, reference_name):
     return reference
 
 # Check whether the resource has been deleted. If it has, then the evaluation is unnecessary.
-def is_applicable_status(configuration_item, event):
+def is_applicable_status(configuration_item, event, **kwargs):
     status = configuration_item['configurationItemStatus']
+    is_applicable = kwargs.get('is_applicable', None)
     event_left_scope = event['eventLeftScope']
+    if is_applicable:
+        return True
     if status in ('ResourceDeleted', 'ResourceDeletedNotRecorded', 'ResourceNotRecorded'):
         print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
     return status in ('OK', 'ResourceDiscovered') and not event_left_scope

--- a/tst/test/rdklib_util_service_test.py
+++ b/tst/test/rdklib_util_service_test.py
@@ -23,6 +23,7 @@ class rdklibUtilServiceTest(unittest.TestCase):
     def test_is_applicable_status(self):
         status_false = ['ResourceDeleted', 'ResourceDeletedNotRecorded', 'ResourceNotRecorded']
         status_true = ['OK', 'ResourceDiscovered']
+        status_flag = True
 
         for status in status_false:
             config_item = build_config_item(status)
@@ -37,6 +38,21 @@ class rdklibUtilServiceTest(unittest.TestCase):
             self.assertTrue(response)
             response = CODE.is_applicable_status(config_item, build_normal_event(True))
             self.assertFalse(response)
+
+        for status in status_false:
+            config_item = build_config_item(status)
+            response = CODE.is_applicable_status(config_item, build_normal_event(False), is_applicable=status_flag)
+            self.assertTrue(response)
+            response = CODE.is_applicable_status(config_item, build_normal_event(True), is_applicable=status_flag)
+            self.assertTrue(response)
+
+        for status in status_true:
+            config_item = build_config_item(status)
+            response = CODE.is_applicable_status(config_item, build_normal_event(False), is_applicable=status_flag)
+            self.assertTrue(response)
+            response = CODE.is_applicable_status(config_item, build_normal_event(True), is_applicable=status_flag)
+            self.assertTrue(response)
+
 
     def test_is_applicable_resource_type(self):
         config_item = build_config_item('OK')


### PR DESCRIPTION
Resource is applicable for evaluation. With unit tests

*Issue #, if available:*

*Description of changes:*
Currently Rdk Lib will automatically bypass a resource evaluation in the event that the resource experiences a "Delete" event. These changes add an optional argument that will allow the user pass a "is_applicable_status" flag in the case that they need their config rule to evaluate a resource even in the case of a Delete event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
