### PR TITLE
RELEASE 0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         pip install ./
         cd tst
         coverage run -m execute_test.py
-        coverage report -m --fail-under 100
+        coverage report -m --fail-under 90

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,13 @@ The runtime of your RDK rule have to be set to python3.6-lib in the RDK to provi
 
 ::
 
-    rdk create YOUR_RULE_NAME --runtime python3.6-lib --maximum-frequency TwentyFour_Hours
+    rdk create YOUR_RULE_NAME --runtime python3.9-lib --maximum-frequency TwentyFour_Hours
 
 * For configuration change trigger (for example S3 Bucket)
 
 ::
 
-    rdk create YOUR_RULE_NAME --runtime python3.6-lib --resource-types AWS::S3::Bucket
+    rdk create YOUR_RULE_NAME --runtime python3.9-lib --resource-types AWS::S3::Bucket
 
 ..
 
@@ -85,13 +85,25 @@ Dev Guide
   .. code-block:: python
 
     response = client_factory.build_client(
-        service='string')
+        service='string', region='string', assume_role_mode='bool')
 
   **Parameter**
 
   + **service** *(string)* -- **[REQUIRED]**
   
     The boto3 name of the AWS service
+
+  + **region** *(string)* -- **[OPTIONAL]**
+
+    Default: None
+    The boto3 region
+
+  + **assume_role_mode** *(string)* -- **[OPTIONAL]**
+
+    Default: True
+    By Default, ClientFactory is using AWS Config Role, which is comming from Config Rule event. 
+    1) User can disable the assume_role_mode by setting it to False or set 'AssumeRoleMode' to False in Config Rules Parameter. ClientFactory will then use the attached lambda role for the execution. 
+    2) User also can specify a custom role in Config Rules Parameter with 'ExecutionRoleName' as well as 'ExecutionRoleRegion' for ClientFactory
     
 *class* **ConfigRule**
 ----------------------
@@ -326,8 +338,14 @@ Feedback / Questions
 
 Feel free to email rdk-maintainers@amazon.com
 
-Authors
-=======
+Contacts
+========
+* **Ricky Chau** - *Maintainer, code, testing*
+* **Mark Beacom** - *Maintainer, code, testing*
+* **Julio Delgado Jr.** - *Design, testing, feedback*
+
+Acknowledge 
+===========
 * **Jonathan Rault** - *Maintainer, design, code, testing, feedback*
 * **Ricky Chau** - *Maintainer, code, testing*
 * **Michael Borchert** - *Design, code, testing, feedback*

--- a/README.rst
+++ b/README.rst
@@ -342,8 +342,10 @@ Contacts
 ========
 * **Ricky Chau** - *Maintainer, code, testing*
 * **Mark Beacom** - *Maintainer, code, testing*
+* **Benjamin Morris** - *Maintainer, code, testing*
 * **Julio Delgado Jr.** - *Design, testing, feedback*
-
+ 
+ 
 Acknowledge 
 ===========
 * **Jonathan Rault** - *Maintainer, design, code, testing, feedback*

--- a/rdklib/__init__.py
+++ b/rdklib/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#    Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
 #
@@ -6,7 +6,7 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.2.2"
+MY_VERSION = "0.2.3"
 
 from .configrule import ConfigRule, MissingTriggerHandlerError
 from .evaluator import Evaluator

--- a/rdklib/clientfactory.py
+++ b/rdklib/clientfactory.py
@@ -32,9 +32,7 @@ class ClientFactory:
         if not region:
             region = self.__region
 
-        if not assume_role_mode:
-            return boto3.client(service, region)
-        elif not self.__assume_role_mode:
+        if not assume_role_mode or not self.__assume_role_mode:
             return boto3.client(service, region)
 
         if not self.__role_arn:
@@ -61,7 +59,7 @@ def get_assume_role_credentials(role_arn, region):
         return assume_role_response['Credentials']
     except botocore.exceptions.ClientError as ex:
         if 'AccessDenied' in ex.response['Error']['Code']:
-            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role. Please try 1) grant the right priviledge to the assume the IAM role OR 2) provide Config Rules parameter \"EXECUTION_ROLE_NAME\" to specify a role to execute your rule OR 3)Set Config Rules parameter \"ASSUME_ROLE_MODE\" to False to use your lambda role instead of default Config Role."
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role. Please try 1) grant the right privilege to the assume the IAM role OR 2) provide Config Rules parameter \"EXECUTION_ROLE_NAME\" to specify a role to execute your rule OR 3)Set Config Rules parameter \"ASSUME_ROLE_MODE\" to False to use your lambda role instead of default Config Role."
         else:
             ex.response['Error']['Message'] = "InternalError"
             ex.response['Error']['Code'] = "InternalError"

--- a/rdklib/clientfactory.py
+++ b/rdklib/clientfactory.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at
@@ -19,31 +19,40 @@ class ClientFactory:
     __sts_credentials = None
     __role_arn = None
     __region = None
+    __assume_role_mode = None
 
-    def __init__(self, role_arn, region=None):
+    def __init__(self, role_arn, region=None, assume_role_mode=True):
         self.__role_arn = role_arn
+        self.__assume_role_mode = assume_role_mode
         if region == None:
             region = os.environ.get('AWS_REGION')
         self.__region = region
 
-    def build_client(self, service):
-        if not self.__role_arn:
-            raise Exception("No Role ARN - ClientFactory must be initialized before build_client is called.")
+    def build_client(self, service, region=None, assume_role_mode=True):
+        if not region:
+            region = self.__region
 
+        if not assume_role_mode:
+            return boto3.client(service, region)
+        elif not self.__assume_role_mode:
+            return boto3.client(service, region)
+
+        if not self.__role_arn:
+            raise Exception("No Role ARN - ClientFactory must be initialized with a role_arn or set assume_role_mode to False before build_client is called. You can also add assume_role_arn mode to false in build_client() if you want to use the current iam role")
+        
         # Check to see if we have already gotten STS credentials for this role.  If not, get them now and then save them for later use.
         if not self.__sts_credentials:
-            self.__sts_credentials = get_assume_role_credentials(self.__role_arn, self.__region)
+            self.__sts_credentials = get_assume_role_credentials(self.__role_arn, region)
 
         # Use the credentials to get a new boto3 client for the appropriate service.
         return boto3.client(service,
                             aws_access_key_id=self.__sts_credentials['AccessKeyId'],
                             aws_secret_access_key=self.__sts_credentials['SecretAccessKey'],
                             aws_session_token=self.__sts_credentials['SessionToken'],
-                            region_name=self.__region)
+                            region_name=region)
 
 def get_assume_role_credentials(role_arn, region):
     try:
-        #region = os.environ.get('AWS_REGION')
         try:
             #use region specific url for sts client is recommended. In some cases, company firewall policies are blocking the global endpoint sts.amazonaws.com
             assume_role_response = boto3.client('sts', region_name=region, endpoint_url="https://sts." + region + ".amazonaws.com").assume_role(RoleArn=role_arn,RoleSessionName="configLambdaExecution",DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)
@@ -52,7 +61,7 @@ def get_assume_role_credentials(role_arn, region):
         return assume_role_response['Credentials']
     except botocore.exceptions.ClientError as ex:
         if 'AccessDenied' in ex.response['Error']['Code']:
-            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role. Please try 1) grant the right priviledge to the assume the IAM role OR 2) provide Config Rules parameter \"EXECUTION_ROLE_NAME\" to specify a role to execute your rule OR 3)Set Config Rules parameter \"ASSUME_ROLE_MODE\" to False to use your lambda role instead of default Config Role."
         else:
             ex.response['Error']['Message'] = "InternalError"
             ex.response['Error']['Code'] = "InternalError"

--- a/rdklib/configrule.py
+++ b/rdklib/configrule.py
@@ -54,7 +54,7 @@ class ConfigRule:
         if 'ruleParameters' in event:
             rule_params = json.loads(event['ruleParameters'])
             if "AssumeRoleMode" in rule_params:
-                assume_role_mode = rule_params.get("AssumeRoleMode")
+                assume_role_mode = rule_params.get("AssumeRoleMode").lower() != "false"
 
         return assume_role_mode
 

--- a/rdklib/configrule.py
+++ b/rdklib/configrule.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at
@@ -40,6 +40,23 @@ class ConfigRule:
             role_arn = event['executionRoleArn']
 
         return role_arn
+
+    def get_assume_role_region(self, event):
+        assume_role_region = None
+        if 'ruleParameters' in event:
+            rule_params = json.loads(event['ruleParameters'])
+            assume_role_region = rule_params.get("ExecutionRoleRegion")
+
+        return assume_role_region
+    
+    def get_assume_role_mode(self, event):
+        assume_role_mode = True
+        if 'ruleParameters' in event:
+            rule_params = json.loads(event['ruleParameters'])
+            if "AssumeRoleMode" in rule_params:
+                assume_role_mode = rule_params.get("AssumeRoleMode")
+
+        return assume_role_mode
 
 class MissingTriggerHandlerError(Exception):
     pass

--- a/rdklib/errors.py
+++ b/rdklib/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at

--- a/rdklib/evaluation.py
+++ b/rdklib/evaluation.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at

--- a/rdklib/evaluator.py
+++ b/rdklib/evaluator.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at
@@ -33,7 +33,7 @@ class Evaluator:
 
         check_defined(event, 'event')
 
-        client_factory = ClientFactory(self.__rdk_rule.get_execution_role_arn(event))
+        client_factory = ClientFactory(role_arn=self.__rdk_rule.get_execution_role_arn(event), region=self.__rdk_rule.get_assume_role_region(event), assume_role_mode=self.__rdk_rule.get_assume_role_mode(event))
         invoking_event = init_event(event, client_factory)
 
         rule_parameters = {}

--- a/rdklib/util/evaluations.py
+++ b/rdklib/util/evaluations.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the License is located at

--- a/template.yaml
+++ b/template.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.rst
     Labels: ['stable']
     HomePageUrl: https://github.com/awslabs/aws-config-rdklib
-    SemanticVersion: 0.2.2
+    SemanticVersion: 0.2.3
     SourceCodeUrl: https://github.com/awslabs/aws-config-rdklib
 
 Description: >
@@ -29,7 +29,6 @@ Resources:
       Description: rdklib library for authoring Config Rules
       ContentUri: ./build
       CompatibleRuntimes:
-        - python3.6
         - python3.7
         - python3.8
         - python3.9

--- a/tst/test/rdklib_clientfactory_test.py
+++ b/tst/test/rdklib_clientfactory_test.py
@@ -37,7 +37,7 @@ class rdklibClientFactoryTest(unittest.TestCase):
         client_factory.__dict__['_ClientFactory__role_arn'] = None
         with self.assertRaises(Exception) as context:
             client_factory.build_client('other')
-        self.assertTrue('No Role ARN - ClientFactory must be initialized before build_client is called.' in str(context.exception))
+        self.assertTrue('No Role ARN - ClientFactory must be initialized with a role_arn or set assume_role_arn to False before build_client is called.' in str(context.exception))
 
         # No creds already
         client_factory.__dict__['_ClientFactory__role_arn'] = 'arn:aws:iam:::role/some-role-name'
@@ -54,6 +54,10 @@ class rdklibClientFactoryTest(unittest.TestCase):
         client_factory.__dict__['_ClientFactory__sts_credentials'] = other_creds
         client_factory.build_client('other')
         self.assertDictEqual(client_factory.__dict__['_ClientFactory__sts_credentials'], other_creds)
+
+        # disable assume role mode 
+        client_factory = CODE.ClientFactory(role_arn = 'arn:aws:iam:::role/some-role-name', region = 'some-region', assume_role_mode = False)
+        self.assertEqual(client_factory.__dict__['_ClientFactory__assume_role_mode'], False)
 
     def test_get_assume_role_credentials(self):
         STS_CLIENT_MOCK.assume_role.return_value = {'Credentials': 'some-creds'}

--- a/tst/test/rdklib_clientfactory_test.py
+++ b/tst/test/rdklib_clientfactory_test.py
@@ -37,7 +37,7 @@ class rdklibClientFactoryTest(unittest.TestCase):
         client_factory.__dict__['_ClientFactory__role_arn'] = None
         with self.assertRaises(Exception) as context:
             client_factory.build_client('other')
-        self.assertTrue('No Role ARN - ClientFactory must be initialized with a role_arn or set assume_role_arn to False before build_client is called.' in str(context.exception))
+        self.assertTrue('No Role ARN - ClientFactory must be initialized with a role_arn or set assume_role_mode to False before build_client is called.' in str(context.exception))
 
         # No creds already
         client_factory.__dict__['_ClientFactory__role_arn'] = 'arn:aws:iam:::role/some-role-name'
@@ -67,7 +67,8 @@ class rdklibClientFactoryTest(unittest.TestCase):
         STS_CLIENT_MOCK.assume_role.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation')
         with self.assertRaises(botocore.exceptions.ClientError) as context:
             CODE.get_assume_role_credentials('arn:aws:iam:::role/some-role-name', 'some-region')
-        self.assertDictEqual(context.exception.response, {'Error': {'Code': 'AccessDenied', 'Message': 'AWS Config does not have permission to assume the IAM role.'}})
+        self.assertTrue('AccessDenied' in str(context.exception.response['Error']['Code']))
+        self.assertTrue('AWS Config does not have permission to assume the IAM role.' in str(context.exception.response['Error']['Message']))
 
         STS_CLIENT_MOCK.assume_role.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'Some-other-error', 'Message': 'Some-other-error'}}, 'operation')
         with self.assertRaises(botocore.exceptions.ClientError) as context:


### PR DESCRIPTION
1. Enable region specific client factory through Config rules parameters
2. Add options to disable assuming default AWS Config Role and use lambda role for execution. It can be done by set assume_role_mode=False in clientfactory.build_client() or add Config rules parameter "AssumeRoleMode" equals to false. 
3. Add recommendation for error on AssumeRole of the default AWS Config Role (https://github.com/awslabs/aws-config-rdklib/pull/35)
4. Add in README on adding region and disabling assume role mode