### PR TITLE
Update python package version classifiers and fix styling for pep8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,26 +29,29 @@ class build_py(build_py_orig):
             if not any(fnmatch.fnmatchcase(file, pat=pattern) for pattern in excluded)
         ]
 
-setup(name='rdklib',
-      version=MY_VERSION,
-      description='Rule Development Kit Library for AWS Config',
-      long_description=readme(),
-      url='https://github.com/awslabs/aws-config-rdklib/',
-      author='RDK Maintainers',
-      author_email='rdk-maintainers@amazon.com',
-      license='Apache License Version 2.0',
-      packages=find_namespace_packages(),
-      cmdclass={'build_py': build_py},
-      install_requires=[
-          'rdk',
-          'boto3',
-          'botocore'
-      ],
-      classifiers=[
+setup(
+    name='rdklib',
+    version=MY_VERSION,
+    description='Rule Development Kit Library for AWS Config',
+    long_description=readme(),
+    url='https://github.com/awslabs/aws-config-rdklib/',
+    author='RDK Maintainers',
+    author_email='rdk-maintainers@amazon.com',
+    license='Apache License Version 2.0',
+    packages=find_namespace_packages(),
+    cmdclass={'build_py': build_py},
+    install_requires=[
+        'rdk',
+        'boto3',
+        'botocore'
+    ],
+    classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-      ],
-      zip_safe=False,
-      include_package_data=True)
+        "Programming Language :: Python :: 3.9",
+    ],
+    zip_safe=False,
+    include_package_data=True,
+)


### PR DESCRIPTION
*Issue #, if available:* #38

*Description of changes:* This change modifies the python package classifiers associated with this module.  These classifiers are visible in pypi along with other package meta.  Additionally, this PR resolves some pep-8 issues (4-space indentation)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
