### PR TITLE
Remove remaining 3.6 python references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Install the library locally
 Create a rule using the RDK 
 ---------------------------
 
-The runtime of your RDK rule have to be set to python3.6-lib in the RDK to provide you the Rule template.
+The runtime of your RDK rule have to be set to python3.9-lib in the RDK to provide you the Rule template.
 
 * For periodic trigger:
 

--- a/rdklib_addon_to_rdk_workshop/README.md
+++ b/rdklib_addon_to_rdk_workshop/README.md
@@ -21,11 +21,11 @@ The **RDKlib Add-On** has the objective to take the same example, MFA_ENABLED_RU
 
 - Periodic Trigger Example:
 
-      rdk create RULE_NAME --runtime python3.6-lib --maximum-frequency TwentyFour_Hours
+      rdk create RULE_NAME --runtime python3.9-lib --maximum-frequency TwentyFour_Hours
 
 - Configuration Change Trigger Example (for IAM User)
 
-      rdk create YOUR_RULE_NAME --runtime python3.6-lib --resource-types AWS::IAM::User
+      rdk create YOUR_RULE_NAME --runtime python3.9-lib --resource-types AWS::IAM::User
 
 ## Task 3: Write the Code
 


### PR DESCRIPTION
*Issue #, if available:* x

*Description of changes:*  The purpose of this PR is to remove the remaining Python 3.6 references from documentation (that were mistakenly missed).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
