### PR TITLE
Support Python 3.12 / Achieve coverage 100%

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -38,7 +38,7 @@ jobs:
   #   name: Run Unit Tests
   #   strategy:
   #     matrix:
-  #       version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+  #       version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
   #       os: [ubuntu-latest]
   #   runs-on: ${{ matrix.os }}
   #   steps:
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Dependencies
         uses: "./.github/actions/dep-setup"
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run Security Checks
         shell: bash

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with mkdocs
 mkdocs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@
 #        http://aws.amazon.com/apache2.0/
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+[project]
+name = "rdklib"
+requires-python = ">=3.7"
+
 [tool.poetry]
 name = "rdklib"
 version = "0.3.6"
@@ -49,11 +53,10 @@ line_length = 120
 
 [tool.black]
 line-length = 120
-target-version = ["py37"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py37"
 
 [tool.poe.tasks]
 isort = "isort --profile=black ."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 include = [
     "README.md",
@@ -48,11 +49,11 @@ line_length = 120
 
 [tool.black]
 line-length = 120
-target-version = ["py311"]
+target-version = ["py37"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py37"
 
 [tool.poe.tasks]
 isort = "isort --profile=black ."

--- a/rdklib/evaluation.py
+++ b/rdklib/evaluation.py
@@ -37,7 +37,7 @@ class Evaluation:
         self.complianceType = complianceType
 
     def __repr__(self):
-        return f"Evaluation(annotation='{self.annotation}', complianceResourceId='{self.complianceResourceId}', complianceResourceType='{self.complianceResourceType}', complianceType='{self.complianceType}')"
+        return f"Evaluation(annotation='{self.annotation}', resourceId='{self.complianceResourceId}', resourceType='{self.complianceResourceType}', complianceType='{self.complianceType}')"
 
     def __eq__(self, other):
         return (

--- a/template.yaml
+++ b/template.yaml
@@ -34,6 +34,7 @@ Resources:
         - python3.9
         - python3.10
         - python3.11
+        - python3.12
       LicenseInfo: "Apache License, Version 2.0"
 
 Outputs:

--- a/tst/test/rdklib_clientfactory_test.py
+++ b/tst/test/rdklib_clientfactory_test.py
@@ -1,10 +1,10 @@
-import unittest
-from unittest.mock import patch, MagicMock
-import botocore
 import importlib
-
-import sys
 import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import botocore
 
 # Get the absolute path of the current script
 current_script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -99,3 +99,24 @@ class rdklibClientFactoryTest(unittest.TestCase):
         self.assertDictEqual(
             context.exception.response, {"Error": {"Code": "InternalError", "Message": "InternalError"}}
         )
+
+    def test_when_not_assume_role_mode_init(self):
+        """ClientFactory should return the client assume role mode disabled."""
+        client_factory = CODE.ClientFactory(
+            role_arn="arn:aws:iam:::role/some-role-name",
+            region="some-region",
+            assume_role_mode=False,
+        )
+        response = client_factory.build_client("other")
+        self.assertNotEqual(response, STS_CLIENT_MOCK)
+        self.assertEqual(response, OTHER_CLIENT_MOCK)
+
+    def test_when_not_assume_role_mode_call(self):
+        """ClientFactory should return the client assume role mode disabled."""
+        client_factory = CODE.ClientFactory(
+            role_arn="arn:aws:iam:::role/some-role-name",
+            region="some-region",
+        )
+        response = client_factory.build_client("other", assume_role_mode=False)
+        self.assertNotEqual(response, STS_CLIENT_MOCK)
+        self.assertEqual(response, OTHER_CLIENT_MOCK)

--- a/tst/test/rdklib_configrule_test.py
+++ b/tst/test/rdklib_configrule_test.py
@@ -1,9 +1,7 @@
-import unittest
-
 import importlib
-
-import sys
 import os
+import sys
+import unittest
 
 # Get the absolute path of the current script
 current_script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -80,3 +78,30 @@ class rdklibConfigRuleTest(unittest.TestCase):
         self.assertEqual("COMPLIANT", my_changed_rule.evaluate_periodic({}, {}, {}))
         self.assertEqual("NON_COMPLIANT", my_changed_rule.evaluate_change({}, {}, {}, {}))
         self.assertEqual("Some_ARN", my_changed_rule.get_execution_role_arn({}))
+
+    def test_get_assume_role_region(self):
+        """The function: get_assume_role_region() should return appropriate value."""
+        my_empty_rule = TEST_RULE_EMPTY()
+        parameterized = [
+            ({}, None),
+            ({"ruleParameters": "{}"}, None),
+            ({"ruleParameters": '{"ExecutionRoleRegion": "us-west-2"}'}, "us-west-2"),
+        ]
+        for event, expected in parameterized:
+            with self.subTest(event):
+                self.assertEqual(my_empty_rule.get_assume_role_region(event), expected)
+
+    def test_get_assume_role_mode(self):
+        """The function: get_assume_role_mode() should return appropriate value."""
+        my_empty_rule = TEST_RULE_EMPTY()
+        parameterized = [
+            ({}, True),
+            ({"ruleParameters": "{}"}, True),
+            ({"ruleParameters": '{"AssumeRoleMode": "false"}'}, False),
+            ({"ruleParameters": '{"AssumeRoleMode": "FALSE"}'}, False),
+            ({"ruleParameters": '{"AssumeRoleMode": "true"}'}, True),
+            ({"ruleParameters": '{"AssumeRoleMode": "TRUE"}'}, True),
+        ]
+        for event, expected in parameterized:
+            with self.subTest(event):
+                self.assertEqual(expected, my_empty_rule.get_assume_role_mode(event))

--- a/tst/test/rdklib_evaluation_test.py
+++ b/tst/test/rdklib_evaluation_test.py
@@ -1,12 +1,11 @@
+import importlib
 import json
+import os
+import sys
 import unittest
 
 # from rdklib.evaluation import ComplianceType, Evaluation, build_annotation
 
-import importlib
-
-import sys
-import os
 
 # Get the absolute path of the current script
 current_script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -188,3 +187,18 @@ class rdklibEvaluationTest(unittest.TestCase):
             "Annotation": "some-annotation",
         }
         self.assertDictEqual(response, resp_expected)
+
+    def test_evaluation_repr(self):
+        """The function: __repr__() should return the string representation of the object."""
+        evaluation = CODE.Evaluation(
+            CODE.ComplianceType.NON_COMPLIANT,
+            "some-resource-id",
+            "some-resource-type",
+            "Annotation message for test.",
+        )
+        # pylint: disable-next=unused-import,import-outside-toplevel
+        from rdklib.evaluation import Evaluation  # noqa: F401
+
+        # pylint: disable-next=eval-used
+        actual = eval(str(evaluation))  # noqa: DUO104
+        self.assertEqual(actual, evaluation)


### PR DESCRIPTION
*Issue #, if available:*

Now, Python 3.12 is available in Lambda: [Lambda runtimes - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

Let's update support Python version.

*Description of changes:*

I committed atomically, please check each revision:

- [Support Python 3.12](https://github.com/awslabs/aws-config-rdklib/commit/809ad25645f57c1153fd04289f44ec76d895b7d4)
- [Achieve coverage 100%](https://github.com/awslabs/aws-config-rdklib/commit/acde2cd3eb48e5c5f7d9ca7437ed8b8ef0a4d1c4)
- [Fix bug that return val of __repr__() can't eval()](https://github.com/awslabs/aws-config-rdklib/commit/a7b13a41392dd4acbdc3dcb02b16709986220e39)

*Coverage reports*

<details>
  <summary>Python 3.12</summary>
  
```console
======================================================================================================================= test session starts =======================================================================================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.5.0
rootdir: /workspace
configfile: pyproject.toml
plugins: mock-3.14.0
collected 53 items                                                                                                                                                                                                                                                

tst/test/rdklib_clientfactory_test.py ....                                                                                                                                                                                                                  [  7%]
tst/test/rdklib_configrule_test.py ....                                                                                                                                                                                                                     [ 15%]
tst/test/rdklib_evaluation_test.py .........                                                                                                                                                                                                                [ 32%]
tst/test/rdklib_evaluator_test.py ............                                                                                                                                                                                                              [ 54%]
tst/test/rdklib_util_evaluations_test.py .....                                                                                                                                                                                                              [ 64%]
tst/test/rdklib_util_external_test.py .                                                                                                                                                                                                                     [ 66%]
tst/test/rdklib_util_internal_test.py .                                                                                                                                                                                                                     [ 67%]
tst/test/rdklib_util_service_test.py .............                                                                                                                                                                                                          [ 92%]
tst/test/rdklibtest_test_test.py ....                                                                                                                                                                                                                       [100%]

======================================================================================================================== warnings summary =========================================================================================================================
.venv/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /workspace/.venv/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================== 53 passed, 1 warning in 0.81s ==================================================================================================================
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
rdklib/__init__.py               6      0   100%
rdklib/clientfactory.py         38      0   100%
rdklib/configrule.py            37      0   100%
rdklib/errors.py                 2      0   100%
rdklib/evaluation.py            57      0   100%
rdklib/evaluator.py             56      0   100%
rdklib/util/__init__.py          0      0   100%
rdklib/util/evaluations.py      56      0   100%
rdklib/util/external.py         15      0   100%
rdklib/util/internal.py          2      0   100%
rdklib/util/service.py          52      0   100%
----------------------------------------------------------
TOTAL                          321      0   100%
```

</details>

<details>
  <summary>Python 3.7</summary>
  
```console
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.7.17, pytest-7.4.4, pluggy-1.2.0
rootdir: /workspace
plugins: mock-3.11.1
collected 53 items                                                                                                                                                                                                                                                             

tst/test/rdklib_clientfactory_test.py ....                                                                                                                                                                                                                               [  7%]
tst/test/rdklib_configrule_test.py ....                                                                                                                                                                                                                                  [ 15%]
tst/test/rdklib_evaluation_test.py .........                                                                                                                                                                                                                             [ 32%]
tst/test/rdklib_evaluator_test.py ............                                                                                                                                                                                                                           [ 54%]
tst/test/rdklib_util_evaluations_test.py .....                                                                                                                                                                                                                           [ 64%]
tst/test/rdklib_util_external_test.py .                                                                                                                                                                                                                                  [ 66%]
tst/test/rdklib_util_internal_test.py .                                                                                                                                                                                                                                  [ 67%]
tst/test/rdklib_util_service_test.py .............                                                                                                                                                                                                                       [ 92%]
tst/test/rdklibtest_test_test.py ....                                                                                                                                                                                                                                    [100%]

============================================================================================================================== 53 passed in 0.42s ==============================================================================================================================
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
rdklib/__init__.py               6      0   100%
rdklib/clientfactory.py         38      0   100%
rdklib/configrule.py            37      0   100%
rdklib/errors.py                 2      0   100%
rdklib/evaluation.py            56      0   100%
rdklib/evaluator.py             56      0   100%
rdklib/util/__init__.py          0      0   100%
rdklib/util/evaluations.py      56      0   100%
rdklib/util/external.py         15      0   100%
rdklib/util/internal.py          2      0   100%
rdklib/util/service.py          52      0   100%
----------------------------------------------------------
TOTAL                          320      0   100%
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
